### PR TITLE
Make sure we're actually in a p5 context before capturing `this`, so createVector can be used as a general function in other contexts

### DIFF
--- a/src/math/math.js
+++ b/src/math/math.js
@@ -22,8 +22,12 @@ define(function (require) {
    * @param {Number} [y] y component of the vector
    * @param {Number} [z] z component of the vector
    */
-  p5.prototype.createVector = function() {
-    return new p5.Vector(this, arguments);
+  p5.prototype.createVector = function (x, y, z) {
+    if (this instanceof p5) {
+      return new p5.Vector(this, arguments);
+    } else {
+      return new p5.Vector(x, y, z);
+    }
   };
 
   return p5;


### PR DESCRIPTION
The problem is that if you bind `createVector` (intentionally or accidentally) to some other object, the vector is created but with strange values, like:

```javascript
p5.Vector {x: {/*the other object*/}, y: [1, 2]}

//expected
p5.Vector {x: 1, y: 2}
```