### PR TITLE
move color conversions into utility file, add tests for color

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -142,7 +142,8 @@ module.exports = function(grunt) {
             'polargeometry': 'src/var/polargeometry',
             'shim': 'src/var/shim',
             'reqwest': 'node_modules/reqwest/reqwest',
-            'filters': 'src/image/filters'
+            'filters': 'src/image/filters',
+            'utils.color_utils': 'src/utils/color_utils'
           },
           useStrict: true,
           wrap: {

--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -30,9 +30,7 @@ define(function (require) {
    * </div>
    */
   p5.prototype.alpha = function(c) {
-    if (c instanceof p5.Color) {
-      return c.getAlpha();
-    } else if (c instanceof Array) {
+    if (c instanceof p5.Color || c instanceof Array) {
       return this.color(c).getAlpha();
     } else {
       throw new Error('Needs p5.Color or pixel array as argument.');
@@ -59,9 +57,7 @@ define(function (require) {
    * </div>
    */
   p5.prototype.blue = function(c) {
-    if (c instanceof p5.Color) {
-      return c.getBlue();
-    } else if (c instanceof Array) {
+    if (c instanceof p5.Color || c instanceof Array) {
       return this.color(c).getBlue();
     } else {
       throw new Error('Needs p5.Color or pixel array as argument.');
@@ -191,9 +187,7 @@ define(function (require) {
    * </div>
    */
   p5.prototype.green = function(c) {
-    if (c instanceof p5.Color) {
-      return c.getGreen();
-    } else if (c instanceof Array) {
+    if (c instanceof p5.Color || c instanceof Array) {
       return this.color(c).getGreen();
     } else {
       throw new Error('Needs p5.Color or pixel array as argument.');
@@ -298,9 +292,7 @@ define(function (require) {
    * </div>
    */
   p5.prototype.red = function(c) {
-    if (c instanceof p5.Color) {
-      return c.getRed();
-    } else if (c instanceof Array) {
+    if (c instanceof p5.Color || c instanceof Array) {
       return this.color(c).getRed();
     } else {
       throw new Error('Needs p5.Color or pixel array as argument.');

--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -164,6 +164,8 @@ define(function (require) {
   p5.prototype.color = function () {
     if (arguments[0] instanceof p5.Color) {
       return arguments[0];
+    } else if (arguments[0] instanceof Array) {
+      return new p5.Color(this, arguments[0]);
     } else {
       var args = Array.prototype.slice.call(arguments);
       return new p5.Color(this, args);

--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -140,6 +140,7 @@ define(function (require) {
         maxArr[0] = arguments[1];
         maxArr[1] = arguments[1];
         maxArr[2] = arguments[1];
+        maxArr[3] = arguments[1];
       }
       else if (arguments.length > 2) {
         maxArr[0] = arguments[1];

--- a/src/objects/p5.Color.js
+++ b/src/objects/p5.Color.js
@@ -6,6 +6,7 @@
 define(function(require) {
 
   var p5 = require('core');
+  var color_utils = require('utils.color_utils');
   var constants = require('constants');
 
   /**
@@ -19,10 +20,10 @@ define(function(require) {
 
     if (pInst._colorMode === constants.HSB) {
       this.hsba = this.color_array;
-      this.rgba = p5.ColorUtils._hsbToRGB(this.color_array);
+      this.rgba = color_utils.hsbaToRGBA(this.hsba);
     } else {
       this.rgba = this.color_array;
-      this.hsba = p5.ColorUtils._rgbaToHSBA(this.color_array);
+      this.hsba = color_utils.rgbaToHSBA(this.rgba);
     }
 
     return this;
@@ -121,117 +122,6 @@ define(function(require) {
       b,
       a
     ];
-  };
-
-
-  p5.ColorUtils = {};
-
-  p5.ColorUtils._hsbToRGB = function(hsba) {
-    var h = hsba[0];
-    var s = hsba[1];
-    var v = hsba[2];
-    h /= 255;
-    s /= 255;
-    v /= 255;
-    // Adapted from http://www.easyrgb.com/math.html
-    // hsv values = 0 - 1, rgb values = 0 - 255
-    var RGBA = [];
-    if(s===0){
-      RGBA = [Math.round(v*255), Math.round(v*255), Math.round(v*255), hsba[3]];
-    }else{
-      // h must be < 1
-      var var_h = h * 6;
-      if (var_h===6) {
-        var_h = 0;
-      }
-      //Or ... var_i = floor( var_h )
-      var var_i = Math.floor( var_h );
-      var var_1 = v*(1-s);
-      var var_2 = v*(1-s*(var_h-var_i));
-      var var_3 = v*(1-s*(1-(var_h-var_i)));
-      var var_r;
-      var var_g;
-      var var_b;
-      if(var_i===0){
-        var_r = v;
-        var_g = var_3;
-        var_b = var_1;
-      }else if(var_i===1){
-        var_r = var_2;
-        var_g = v;
-        var_b = var_1;
-      }else if(var_i===2){
-        var_r = var_1;
-        var_g = v;
-        var_b = var_3;
-      }else if(var_i===3){
-        var_r = var_1;
-        var_g = var_2;
-        var_b = v;
-      }else if (var_i===4){
-        var_r = var_3;
-        var_g = var_1;
-        var_b = v;
-      }else{
-        var_r = v;
-        var_g = var_1;
-        var_b = var_2;
-      }
-      RGBA= [
-        Math.round(var_r * 255),
-        Math.round(var_g * 255),
-        Math.round(var_b * 255),
-        hsba[3]
-      ];
-    }
-    return RGBA;
-  };
-
-  p5.ColorUtils._rgbaToHSBA = function(rgba) {
-    var var_R = rgba[0]/255;
-    var var_G = rgba[1]/255;
-    var var_B = rgba[2]/255;
-
-    var var_Min = Math.min(var_R, var_G, var_B); //Min. value of RGB
-    var var_Max = Math.max(var_R, var_G, var_B); //Max. value of RGB
-    var del_Max = var_Max - var_Min;             //Delta RGB value 
-
-    var H;
-    var S;
-    var V = var_Max;
-
-    if (del_Max === 0) { //This is a gray, no chroma...
-      H = 0; //HSV results from 0 to 1
-      S = 0;
-    }
-    else { //Chromatic data...
-      S = del_Max/var_Max;
-
-      var del_R = ( ( ( var_Max - var_R ) / 6 ) + ( del_Max / 2 ) ) / del_Max;
-      var del_G = ( ( ( var_Max - var_G ) / 6 ) + ( del_Max / 2 ) ) / del_Max;
-      var del_B = ( ( ( var_Max - var_B ) / 6 ) + ( del_Max / 2 ) ) / del_Max;
-
-      if (var_R === var_Max) {
-        H = del_B - del_G;
-      } else if (var_G === var_Max) {
-        H = 1/3 + del_R - del_B;
-      } else if (var_B === var_Max) {
-        H = 2/3 + del_G - del_R;
-      }
-
-      if (H<0) {
-        H += 1;
-      }
-      if (H>1) {
-        H -= 1;
-      }
-    }
-    return [
-        Math.round(H * 255),
-        Math.round(S * 255),
-        Math.round(V * 255),
-        rgba[3]
-      ];
   };
 
   return p5.Color;

--- a/src/utils/color_utils.js
+++ b/src/utils/color_utils.js
@@ -1,0 +1,134 @@
+/**
+ * @module Utils
+ * @submodule Color Utils
+ * @for p5
+ */
+define(function(require) {
+  var p5 = require('core');
+
+  p5.ColorUtils = {};
+
+  /**
+   * For a color expressed as an HSBA array, return the corresponding RGBA value
+   * 
+   * @param {Array} hsba An 'array' object that represents a list of
+   *                          HSB colors on a scale of 0-255
+   * @return {Array} an array of RGBA values, on a scale of 0-255
+   */
+  p5.ColorUtils.hsbaToRGBA = function(hsba) {
+    var h = hsba[0];
+    var s = hsba[1];
+    var v = hsba[2];
+    h /= 255;
+    s /= 255;
+    v /= 255;
+    // Adapted from http://www.easyrgb.com/math.html
+    // hsv values = 0 - 1, rgb values = 0 - 255
+    var RGBA = [];
+    if(s===0){
+      RGBA = [Math.round(v*255), Math.round(v*255), Math.round(v*255), hsba[3]];
+    } else {
+      // h must be < 1
+      var var_h = h * 6;
+      if (var_h===6) {
+        var_h = 0;
+      }
+      //Or ... var_i = floor( var_h )
+      var var_i = Math.floor( var_h );
+      var var_1 = v*(1-s);
+      var var_2 = v*(1-s*(var_h-var_i));
+      var var_3 = v*(1-s*(1-(var_h-var_i)));
+      var var_r;
+      var var_g;
+      var var_b;
+      if(var_i===0){
+        var_r = v;
+        var_g = var_3;
+        var_b = var_1;
+      }else if(var_i===1){
+        var_r = var_2;
+        var_g = v;
+        var_b = var_1;
+      }else if(var_i===2){
+        var_r = var_1;
+        var_g = v;
+        var_b = var_3;
+      }else if(var_i===3){
+        var_r = var_1;
+        var_g = var_2;
+        var_b = v;
+      }else if (var_i===4){
+        var_r = var_3;
+        var_g = var_1;
+        var_b = v;
+      }else{
+        var_r = v;
+        var_g = var_1;
+        var_b = var_2;
+      }
+      RGBA= [
+        Math.round(var_r * 255),
+        Math.round(var_g * 255),
+        Math.round(var_b * 255),
+        hsba[3]
+      ];
+    }
+    return RGBA;
+  };
+
+  /**
+   * For a color expressed as an RGBA array, return the corresponding HSBA value
+   * 
+   * @param {Array} rgba An 'array' object that represents a list of
+   *                          RGB colors on a scale of 0-255
+   * @return {Array} an array of HSB values, on a scale of 0-255
+   */
+  p5.ColorUtils.rgbaToHSBA = function(rgba) {
+    var var_R = rgba[0]/255;
+    var var_G = rgba[1]/255;
+    var var_B = rgba[2]/255;
+
+    var var_Min = Math.min(var_R, var_G, var_B); //Min. value of RGB
+    var var_Max = Math.max(var_R, var_G, var_B); //Max. value of RGB
+    var del_Max = var_Max - var_Min;             //Delta RGB value 
+
+    var H;
+    var S;
+    var V = var_Max;
+
+    if (del_Max === 0) { //This is a gray, no chroma...
+      H = 0; //HSV results from 0 to 1
+      S = 0;
+    }
+    else { //Chromatic data...
+      S = del_Max/var_Max;
+
+      var del_R = ( ( ( var_Max - var_R ) / 6 ) + ( del_Max / 2 ) ) / del_Max;
+      var del_G = ( ( ( var_Max - var_G ) / 6 ) + ( del_Max / 2 ) ) / del_Max;
+      var del_B = ( ( ( var_Max - var_B ) / 6 ) + ( del_Max / 2 ) ) / del_Max;
+
+      if (var_R === var_Max) {
+        H = del_B - del_G;
+      } else if (var_G === var_Max) {
+        H = 1/3 + del_R - del_B;
+      } else if (var_B === var_Max) {
+        H = 2/3 + del_G - del_R;
+      }
+
+      if (H<0) {
+        H += 1;
+      }
+      if (H>1) {
+        H -= 1;
+      }
+    }
+    return [
+        Math.round(H * 255),
+        Math.round(S * 255),
+        Math.round(V * 255),
+        rgba[3]
+      ];
+  };
+  
+  return p5.ColorUtils;
+});

--- a/test/test.html
+++ b/test/test.html
@@ -44,6 +44,7 @@
   <script src="unit/input/files.js" type="text/javascript" ></script>
   <script src="unit/input/time_date.js" type="text/javascript" ></script>
   <script src="unit/color/setting.js" type="text/javascript" ></script>
+  <script src="unit/color/creating_reading.js" type="text/javascript" ></script>
   <script src="unit/image/loading.js" type="text/javascript" ></script>
   <script src="unit/utils/color_utils.js" type="text/javascript" ></script>
 

--- a/test/test.html
+++ b/test/test.html
@@ -32,6 +32,7 @@
 
   <!-- Spec files -->
   <script src="unit/objects/p5.Vector.js" type="text/javascript" ></script>
+  <script src="unit/objects/p5.Color.js" type="text/javascript" ></script>
   <script src="unit/core/core.js" type="text/javascript" ></script>
   <script src="unit/data/array_functions.js" type="text/javascript" ></script>
   <script src="unit/math/calculation.js" type="text/javascript" ></script>
@@ -44,6 +45,7 @@
   <script src="unit/input/time_date.js" type="text/javascript" ></script>
   <script src="unit/color/setting.js" type="text/javascript" ></script>
   <script src="unit/image/loading.js" type="text/javascript" ></script>
+  <script src="unit/utils/color_utils.js" type="text/javascript" ></script>
 
   <!-- run mocha -->
   <script type="text/javascript" >

--- a/test/unit/color/creating_reading.js
+++ b/test/unit/color/creating_reading.js
@@ -1,0 +1,72 @@
+suite('CreatingReading', function() {
+  
+  // p5 instance
+  var myp5 = new p5(function( sketch ) {
+    sketch.setup = function() {};
+    sketch.draw = function() {};
+  });
+
+  setup(function() {
+    myp5.colorMode(myp5.RGB, 255); 
+  });
+
+  suite('p5.prototype.color', function() {
+    var color;
+
+    suite('color([])', function() {
+      setup(function() {
+        color = myp5.color([1,2,3]);
+      });
+      test('should return a p5.Color', function() {
+        assert.instanceOf(color, p5.Color);
+        assert.deepEqual(color.rgba, [1,2,3,255]);
+      });
+    });
+
+    suite('color(a,b,c)', function() {
+      setup(function() {
+        color = myp5.color(1,2,3);
+      });
+      test('should return a p5.Color', function() {
+        assert.instanceOf(color, p5.Color);
+        assert.deepEqual(color.rgba, [1,2,3,255]);
+      });
+    });
+
+    suite('color(p5.Color)', function() {
+      setup(function() {
+        var tempColor = myp5.color([1,2,3]);
+        color = myp5.color(tempColor);
+      });
+      test('should return a p5.Color', function() {
+        assert.instanceOf(color, p5.Color);
+        assert.deepEqual(color.rgba, [1,2,3,255]);
+      });
+    });
+  });
+
+  suite('p5.prototype.red,green,blue', function() {
+    var color, colorArr;
+
+    setup(function() {
+      colorArr = [1,2,3];
+      color = myp5.color(colorArr);
+    });
+
+    test('p5.prototype.red', function() {
+      assert.equal(myp5.red(colorArr), 1);
+      assert.equal(myp5.red(color), 1);
+    });
+
+    test('p5.prototype.green', function() {
+      assert.equal(myp5.green(colorArr), 2);
+      assert.equal(myp5.green(color), 2);
+    });
+
+    test('p5.prototype.blue', function() {
+      assert.equal(myp5.blue(colorArr), 3);
+      assert.equal(myp5.blue(color), 3);
+    });
+  });
+
+});

--- a/test/unit/objects/p5.Color.js
+++ b/test/unit/objects/p5.Color.js
@@ -1,0 +1,95 @@
+suite('p5.Color', function() {
+  var myp5 = new p5(function( sketch ) {
+    sketch.setup = function() {};
+    sketch.draw = function() {};
+  });
+  var c;
+
+  suite('p5.prototype.color(a,b,c)', function() {
+    setup(function() {
+      c = myp5.color(10, 20, 30, 255);
+    });
+    test('should create instance of p5.Color', function() {
+      assert.instanceOf(c, p5.Color);
+    });
+
+    test('should correctly set RGBA property', function() {
+      assert.deepEqual(c.rgba, [10, 20, 30, 255]);
+    });
+
+    test('should correctly set HSBA property', function() {
+      assert.deepEqual(c.hsba, [149, 170, 30, 255] );
+    });
+
+    test('should correctly set RGBA values', function() {
+      assert.equal(c.getRed(), 10);
+      assert.equal(c.getGreen(), 20);
+      assert.equal(c.getBlue(), 30);
+      assert.equal(c.getAlpha(), 255);
+    });
+
+    test('should correctly set HSB values', function() {
+      assert.equal(c.getHue(), 149);
+      assert.equal(c.getSaturation(), 170);
+      assert.equal(c.getBrightness(), 30);
+    });
+
+    test('should correctly render color string', function() {
+      assert.equal(c.toString(), 'rgba(10,20,30,1)');
+    });
+  });
+
+  // TODO: should this usage be supported?
+  suite.skip('p5.prototype.color([])', function() {
+    setup(function() {
+      c = myp5.color([10, 20, 30]);
+    });
+    test('should create instance of p5.Color', function() {
+      assert.instanceOf(c, p5.Color);
+    });
+    test('should correctly set RGBA property', function() {
+      assert.deepEqual(c.rgba, [10, 20, 30, 255]);
+    });
+  });
+
+  suite('new p5.Color in HSB mode', function() {
+    setup(function() {
+      myp5.colorMode(myp5.HSB);
+      c = myp5.color(149, 170, 30, 255);
+    });
+
+    test('should correctly set HSBA property', function() {
+      assert.deepEqual(c.hsba, [149, 170, 30, 255]);
+    });
+
+    test('should correctly convert to RGBA', function() {
+      assert.deepEqual(c.rgba, [10, 20, 30, 255]);
+    });
+
+    test('should correctly render color string', function() {
+      assert.equal(c.toString(), 'rgba(10,20,30,1)');
+    });
+  });
+
+  suite('new p5.Color with Base 1 colors', function() {
+    var base_1_rgba = [0.2, 0.4, 0.6, 0.5]; 
+    var base_255_rgba = [51, 102, 153, 127.5];
+
+    setup(function() {
+      myp5.colorMode(myp5.RGB, 1);
+      c = myp5.color.apply(myp5, base_1_rgba);
+    });
+
+    test('should correctly set RGBA', function() {
+      assert.deepEqual(c.rgba, base_255_rgba);
+    });
+
+    test('should correctly convert to HSB', function() {
+      assert.deepEqual(c.hsba, p5.ColorUtils.rgbaToHSBA(base_255_rgba));
+    });
+
+    test('should correctly set color string', function() {
+      assert.equal(c.toString(), 'rgba(51,102,153,0.5)');
+    });
+  });
+});

--- a/test/unit/objects/p5.Color.js
+++ b/test/unit/objects/p5.Color.js
@@ -39,8 +39,7 @@ suite('p5.Color', function() {
     });
   });
 
-  // TODO: should this usage be supported?
-  suite.skip('p5.prototype.color([])', function() {
+  suite('p5.prototype.color([])', function() {
     setup(function() {
       c = myp5.color([10, 20, 30]);
     });

--- a/test/unit/utils/color_utils.js
+++ b/test/unit/utils/color_utils.js
@@ -1,0 +1,20 @@
+suite('p5.ColorUtils', function() {
+  var rgba = [100, 150, 200, 255];
+  var hsba = [149, 128, 200, 255];
+
+  suite('rgbaToHSBA', function() {
+    test('rgba converts to hsba', function() {
+      assert.deepEqual(p5.ColorUtils.rgbaToHSBA(rgba), hsba);
+    });
+  });
+
+  suite('hsbaToRGBA', function() {
+    test('hsba converts to rgba', function() {
+      // Because of rounding errors, the green value is off by one
+      // var rgba = [100, 150, 200, 255];
+      rgba = [100, 149, 200, 255];
+
+      assert.deepEqual(p5.ColorUtils.hsbaToRGBA(hsba), rgba);
+    });
+  });
+});


### PR DESCRIPTION
I created a new utils directory and put the color conversion methods in there, not sure if that's okay, I could move it back into p5.Color if you'd rather keep it all together.

Adds a bunch of tests for the p5.Color class and for the color conversion methods.